### PR TITLE
manifest_3.18: use n-mr1 for sepolicy

### DIFF
--- a/devices_3_18.xml
+++ b/devices_3_18.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
-<project path="device/sony/sepolicy" name="device-sony-sepolicy" groups="device" remote="sony" revision="master" />
+<project path="device/sony/sepolicy" name="device-sony-sepolicy" groups="device" remote="sony" revision="n-mr1" />
 <project path="device/sony/common" name="device-sony-common" groups="device" remote="sony" revision="n-mr1" />
 <project path="device/sony/common-init" name="device-sony-common-init" groups="device" remote="sony" revision="n-mr1" />
 


### PR DESCRIPTION
with this we use master only for 4.4 and newer and n-mr1 for 3.1x more easy to follow by external projects
and automatic scritps

Signed-off-by: David Viteri <davidteri91@gmail.com>