### PR TITLE
disable Xperia ExtendedSettings app

### DIFF
--- a/oss.xml
+++ b/oss.xml
@@ -10,6 +10,6 @@
 <project path="vendor/sony-oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
 <project path="vendor/sony-oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />
 <project path="vendor/sony-oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
-<project path="packages/apps/ExtendedSettings" name="packages_apps_ExtendedSettings" groups="device" remote="sony" revision="master" />
+<!-- <project path="packages/apps/ExtendedSettings" name="packages_apps_ExtendedSettings" groups="device" remote="sony" revision="master" /> -->
 <project path="packages/apps/FMRadio" name="packages-apps-FMRadio" groups="device" remote="sony" revision="m-mr1" />
 </manifest>


### PR DESCRIPTION
Recent commits into Xperia ExtendedSettings app introduced code changes not compatible with
legacy Android 6.0 Marshmallow. As a result it is not possible to build this legacy Android
due to build errors while building this app.

Most notably [this commit](https://github.com/sonyxperiadev/packages_apps_ExtendedSettings/commit/2594556917f53f8ec2b71e04dbde8567b4d66e2a), which added ```android:directBootAware="true"``` into AndroidManifest.xml. This flag is not recognized in AOSP 6.0.

As this application is not essential to AOSP build, this commit removes the app from AOSP project list.

Signed-off-by: Vladimir Zahradnik <vladimir.zahradnik@gmail.com>