### PR TITLE
Initial odmcheck (3/4)

### DIFF
--- a/oss.xml
+++ b/oss.xml
@@ -10,6 +10,7 @@
 <project path="vendor/sony-oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
 <project path="vendor/sony-oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />
 <project path="vendor/sony-oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
+<project path="vendor/sony-oss/odmcheck" name="vendor-sony-oss-odmcheck" groups="device" remote="sony" revision="master" />
 <project path="packages/apps/ExtendedSettings" name="packages_apps_ExtendedSettings" groups="device" remote="sony" revision="master" />
 <project path="packages/apps/FMRadio" name="packages-apps-FMRadio" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/json-c" name="json-c" groups="device" remote="sony" revision="master" />


### PR DESCRIPTION
Odmcheck will block init until exited. If a mismatch between odm partition and the build props is detected a warning screen will be shown. Currently this warning screen just has a simple placeholder UI with the version information shown on a blue background. The warning screen will be shown for 10 seconds, then the boot will resume regardless. Once everything is in place and works fine, after changing a build flag, odmcheck will instead shutdown the device after the 10 seconds.