### PR TITLE
[master] Do not track AOSP Camera HAL

### DIFF
--- a/LA.UM.5.7.r1.xml
+++ b/LA.UM.5.7.r1.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+<remove-project name="platform/hardware/qcom/camera" />
 <project path="device/sony/common-headers" name="device-sony-common-headers" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />
 <project path="device/sony/common-kernel" name="vendor-sony-kernel" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />
 <project path="hardware/qcom/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />

--- a/untracked.xml
+++ b/untracked.xml
@@ -5,6 +5,7 @@
 <remove-project name="device/google/accessory/demokit" />
 <remove-project name="device/google/dragon-kernel" />
 <remove-project name="device/google/marlin-kernel" />
+<remove-project name="device/google/wahoo-kernel" />
 <remove-project name="device/huawei/angler-kernel" />
 <remove-project name="device/lge/bullhead-kernel" />
 <remove-project name="device/linaro/bootloader/OpenPlatformPkg" />
@@ -26,6 +27,7 @@
 <remove-project name="platform/hardware/intel/img/psb_video" />
 <remove-project name="platform/hardware/intel/sensors" />
 <remove-project name="platform/hardware/marvell/bt" />
+<remove-project name="platform/hardware/qcom/msm8x09" />
 <remove-project name="platform/hardware/qcom/msm8960" />
 <remove-project name="platform/hardware/qcom/msm8994" />
 <remove-project name="platform/hardware/qcom/msm8996" />


### PR DESCRIPTION
Camera HAL was added back to AOSP and we don't need this because we use our own Camera HAL.
And also remove wahoo prebuilt kernel and depricated hardware/qcom/msm8x09.