### PR TITLE
[android-8.1.0_r26] Remove kernel/tests project

### DIFF
--- a/untracked.xml
+++ b/untracked.xml
@@ -34,6 +34,7 @@
 <remove-project name="device/linaro/bootloader/edk2" />
 <remove-project name="device/linaro/hikey" />
 <remove-project name="device/linaro/hikey-kernel" />
+<remove-project name="kernel/tests" />
 <remove-project name="platform/hardware/intel/audio_media" />
 <remove-project name="platform/hardware/intel/bootstub" />
 <remove-project name="platform/hardware/intel/common/bd_prov" />


### PR DESCRIPTION
At least for me it slows me traversing (tab-tab) the hierarchy through kernel/msm/sony*.