### PR TITLE
Copy os_pickup.bp for vendor/qcom/opensource/interfaces

### DIFF
--- a/oss.xml
+++ b/oss.xml
@@ -2,7 +2,9 @@
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="master" />
-<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.UM.6.3.r1" />
+<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.UM.6.3.r1" >
+  <copyfile dest="vendor/qcom/opensource/Android.bp" src="os_pickup.bp" />
+</project>
 <project path="vendor/qcom/opensource/fm" name="vendor-qcom-opensource-fm" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="o-mr1" />
 <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />


### PR DESCRIPTION
* Soong is unable to include 'interfaces' folder without it.