### PR TITLE
Fix sync error

### DIFF
--- a/untracked.xml
+++ b/untracked.xml
@@ -60,7 +60,7 @@
 <remove-project name="platform/hardware/qcom/msm8x27" />
 <remove-project name="platform/hardware/qcom/msm8x84" />
 <remove-project name="platform/hardware/qcom/sdm845/bt" />
-<remove-project name="platform/hardware/qcom/sdm845/data" />
+<remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
 <remove-project name="platform/hardware/qcom/sdm845/display" />
 <remove-project name="platform/hardware/qcom/sdm845/media" />
 <remove-project name="platform/hardware/qcom/sdm845/thermal" />


### PR DESCRIPTION
Error while syncing:

`fatal: remove-project element specifies non-existent project: platform/hardware/qcom/sdm845/data`

platform/hardware/qcom/sdm845/data wasn't a project, but
platform/hardware/qcom/sdm845/data/ipacfg-mgr was.

Remaining issue is to remove the link created in hardware/qcom/sdm845/Android.mk...