### PR TITLE
Make hardware/qcom/sdm845 subdirs usable again

### DIFF
--- a/devices.xml
+++ b/devices.xml
@@ -2,7 +2,9 @@
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 <project path="device/sony/sepolicy" name="device-sony-sepolicy" groups="device" remote="sony" revision="master" />
-<project path="device/sony/common" name="device-sony-common" groups="device" remote="sony" revision="master" />
+<project path="device/sony/common" name="device-sony-common" groups="device" remote="sony" revision="master" >
+  <linkfile src="hardware/Android.mk" dest="hardware/qcom/sdm845/Android.mk" />
+</project>
 
 <!--msm8956-->
 <project path="device/sony/loire" name="device-sony-loire" groups="device" remote="sony" revision="master" />


### PR DESCRIPTION
After removing the hardware/qcom/sdm845/data/ipacfg-mgr we lost the
hardware/qcom/sdm845/Android.mk file that was sourced (linked) from there,
so take a similar enough one from here.

It's a hack, but I cannot think of a better compromise for now.

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>