### PR TITLE
Fix qcom sdm845 media path for legacy

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -4,7 +4,9 @@
 
 <remove-project name="platform/hardware/qcom/gps" />
 <remove-project name="platform/hardware/qcom/sdm845/gps" />
+<remove-project name="platform/hardware/qcom/media" />
 <project path="hardware/qcom/gps" name="platform/hardware/qcom/sdm845/gps" remote="aosp" groups="qcom_sdm845" revision="master" />
+<project path="hardware/qcom/media" name="platform/hardware/qcom/sdm845/media" remote="aosp" groups="qcom_sdm845" revision="master" />
 
 <project path="hardware/qcom/display/msmfb" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.6.3.r1" />
 <project path="hardware/qcom/display/sde" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.7.3.r1" />


### PR DESCRIPTION
Same as [gps: GPS HAL update and migration to qcom folder ](https://github.com/sonyxperiadev/local_manifests/commit/5a54c34861ec9fc19fcfc527ac464720544b2399#diff-767b3adf2517b5959e6a28bc97d7fc2e).

Needed because camera will not build because of missing libs from mm-core.