### PR TITLE
[DONOTMERGE] untracked_devices: Untrack coral, which was added in the latest monthly.

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -24,6 +24,9 @@
 	<remove-project name="device/google/bonito-kernel" />
 	<remove-project name="device/google/bonito-sepolicy" />
 	<remove-project name="device/google/contexthub" />
+	<remove-project name="device/google/coral" />
+	<remove-project name="device/google/coral-kernel" />
+	<remove-project name="device/google/coral-sepolicy" />
 	<remove-project name="device/google/crosshatch" />
 	<remove-project name="device/google/crosshatch-kernel" />
 	<remove-project name="device/google/crosshatch-sepolicy" />


### PR DESCRIPTION
This device depends on other repositories that have also been untracked,
just like all other Pixel devices.

DONOTMERGE: I am on the P4 tags (for no good reason really, it's probably quite close to P3 and others). This can stay open untill Google _finally_ merges all devices into a single tag.