### PR TITLE
[android-10.0.0_r15] LA.UM.7.1.r1: Add data-kernel techpack driver

### DIFF
--- a/LA.UM.7.1.r1.xml
+++ b/LA.UM.7.1.r1.xml
@@ -5,6 +5,7 @@
 <project path="kernel/sony/msm-4.14/common-kernel" name="kernel-sony-msm-4.14-common" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" clone-depth="1"/>
 <project path="kernel/sony/msm-4.14/kernel" name="kernel" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="kernel/sony/msm-4.14/kernel/techpack/audio" name="kernel-techpack-audio" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
+<project path="kernel/sony/msm-4.14/kernel/techpack/data-kernel" name="kernel-techpack-data-kernel" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="kernel/sony/msm-4.14/kernel/arch/arm64/configs/sony" name="kernel-defconfig" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />


### PR DESCRIPTION
This techpack is useful to get advanced rmnet functionality, such as proper
offloading, qos and battery savings.

This commit is missing on branch android-10.0.0_r15. Without it, the kernel fails to build.