### PR TITLE
[LOCAL_MANIFESTS] Add legacy venus HAL and switch SM8150 to 8.1

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -11,6 +11,7 @@
 
 <project path="hardware/qcom/display/sde" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="hardware/qcom/media/sm8150" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
+<project path="hardware/qcom/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
 
 <project path="hardware/qcom/media/sdm845" name="platform/hardware/qcom/sdm845/media" groups="qcom_sdm845" remote="aosp" />
 

--- a/qcom.xml
+++ b/qcom.xml
@@ -10,7 +10,7 @@
 <project path="hardware/qcom/gps" name="platform/hardware/qcom/sdm845/gps" remote="aosp" groups="qcom_sdm845" />
 
 <project path="hardware/qcom/display/sde" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
-<project path="hardware/qcom/media/sm8150" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
+<project path="hardware/qcom/media/sm8150" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="hardware/qcom/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
 
 <project path="hardware/qcom/media/sdm845" name="platform/hardware/qcom/sdm845/media" groups="qcom_sdm845" remote="aosp" />


### PR DESCRIPTION
The LA.UM.8.1.r1 codebase is the one that we want to use, since
the kernel vidc driver will be upgraded to it very soon.

This HAL is anyway working with the 7.1.r1 driver so no
functional issues will appear while the kernel gets migrated.

As for the rest, the new SDM660-libion HAL is what we now want
for legacy SoCs on kernel 4.14 in order to get hardware enc/dec
working through Venus.