### PR TITLE
[1/2] qcom: Remove os_pickup link

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -23,7 +23,5 @@
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/display-commonsys-intf" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
-<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" >
-  <linkfile dest="vendor/qcom/opensource/Android.bp" src="os_pickup.bp" />
-</project>
+<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 </manifest>


### PR DESCRIPTION
On Q, soong will traverse all directories.
The pickup-subdirs crutch is no longer needed.

[2/2] at https://github.com/sonyxperiadev/vendor-qcom-opensource-interfaces/pull/8 removes the `os_pickup.bp` file.