### PR TITLE
[android-10.0.0_r33] qcom: Switch camera to new HAL

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -14,7 +14,7 @@
 
 <project path="hardware/qcom/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
 
-<project path="vendor/qcom/opensource/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+<project path="vendor/qcom/opensource/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.8.11.r1" />
 <project path="vendor/qcom/opensource/core-utils" name="vendor-qcom-opensource-core-utils" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="q-mr1" />


### PR DESCRIPTION
    v6 includes blobs for new camera and kernel driver upgrade has been merged.
    So lets switch to new HAL.


cherry-picked from master without the commit it is no longer possible to build current android-10.0.0_r33.