### PR TITLE
untracked/qcom: do away with default hal locations

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -8,11 +8,11 @@
 
 <project path="hardware/qcom/gps" name="platform/hardware/qcom/sdm845/gps" remote="aosp" groups="qcom_sdm845" />
 
-<project path="hardware/qcom/display/sde" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
-<project path="hardware/qcom/media/sm8150" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
-<project path="hardware/qcom/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
+<project path="vendor/qcom/opensource/display" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+<project path="vendor/qcom/opensource/media/sm8150" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+<project path="vendor/qcom/opensource/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
 
-<project path="hardware/qcom/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
+<project path="vendor/qcom/opensource/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
 
 <project path="vendor/qcom/opensource/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.8.11.r1" />
 <project path="vendor/qcom/opensource/core-utils" name="vendor-qcom-opensource-core-utils" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+    <remove-project name="platform/hardware/qcom/display" />
+    <remove-project name="platform/hardware/qcom/media" />
     <remove-project name="platform/hardware/qcom/msm8x09" />
     <remove-project name="platform/hardware/qcom/msm8960" />
     <remove-project name="platform/hardware/qcom/msm8994" />


### PR DESCRIPTION
The display, media and ipa hals actively used by the project were placed into subdirectories of the default hal locations.
This was done for the sole purpose of not having them automatically included, so that they can be explicitly included in device/sony/common/hardware/qcom/Android.mk.
That unfortunately introduced a nasty side effect, which is that 'repo status' would always report that the build tree is dirty.
Avoid that nastiness by opting to move the hals to a different location, and adding build guards to them to avoid erroneous inclusion.
With this it is also possible to untrack the default display and media hals.