### PR TITLE
Remove unused broadcom repos

### DIFF
--- a/broadcom.xml
+++ b/broadcom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-<project path="vendor/broadcom/bt-fm" name="vendor-broadcom-bt-fm" groups="device" remote="sony" revision="q-mr1" />
 <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" groups="device" remote="sony" revision="q-mr1" />
 </manifest>

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+    <remove-project name="platform/hardware/broadcom/wlan" />
     <remove-project name="platform/hardware/qcom/display" />
     <remove-project name="platform/hardware/qcom/gps" />
     <remove-project name="platform/hardware/qcom/media" />


### PR DESCRIPTION
The bt-fm repo was originally intended for FM radio related things, but never used in recent Android versions.

The wlan repo contained firmware and configs for bcmdhd devices, but as of k4.9, all bcmdhd devices have been ported to brcmfmac.
The file `hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk` is lazily `-include`d by files in `vendor/broadcom`, so removing the hardware/broadcom/wlan repo will stop it from overwriting our own wifi config overlay files.
