### PR TITLE
Restoring some of sdm845 and sm8150 projects to execute proper build from the scratch

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -4,7 +4,6 @@
 
 <remove-project name="platform/hardware/qcom/gps" />
 <remove-project name="platform/hardware/qcom/sdm845/gps" />
-<remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
 
 <project path="hardware/qcom/gps" name="platform/hardware/qcom/sdm845/gps" remote="aosp" groups="qcom_sdm845" />
 

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -13,7 +13,6 @@
     <remove-project name="platform/hardware/qcom/sdm845/media" />
     <remove-project name="platform/hardware/qcom/sdm845/thermal" />
     <remove-project name="platform/hardware/qcom/sdm845/vr" />
-    <remove-project name="platform/hardware/qcom/sm8150/display" />
     <remove-project name="platform/hardware/qcom/sm8150/gps" />
     <remove-project name="platform/hardware/qcom/sm8150/media" />
     <remove-project name="platform/hardware/qcom/sm8150/thermal" />

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -13,7 +13,6 @@
     <remove-project name="platform/hardware/qcom/sdm845/media" />
     <remove-project name="platform/hardware/qcom/sdm845/thermal" />
     <remove-project name="platform/hardware/qcom/sdm845/vr" />
-    <remove-project name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" />
     <remove-project name="platform/hardware/qcom/sm8150/display" />
     <remove-project name="platform/hardware/qcom/sm8150/gps" />
     <remove-project name="platform/hardware/qcom/sm8150/media" />


### PR DESCRIPTION
# The overview

Over the last couple of days, I'm trying to build AOSP for Sony Xperia 10 _(edit: corrected the device name)_ (codename: kirin) following the official tutorial (which is a little outdated) on the official Sony Open Devices page https://developer.sony.com/develop/open-devices/guides/aosp-build-instructions/build-aosp-android-android-10-0-0. However, I was getting errors and I was unable to finish the build.


# The procedure

After populating .repo/local_manifests folder cloning the local_manifests repository branch [android-10.0.0_r33](https://github.com/sonyxperiadev/local_manifests/tree/android-10.0.0_r33) and issued
1. `repo sync`
1. `./repo_update.sh`

I was unable to make proper build after running the one-liner below:
`source build/envsetup.sh && lunch aosp_i3113-eng && m`


# The problem

The problems I've faced were basically related to missing files:
* First build:
```
FAILED: out/soong/.bootstrap/build.ninja
out/soong/.minibootstrap/minibp -t -l out/.module_paths/Android.bp.list -b out/soong -n out -d out/soong/.bootstrap/build.ninja.d -globFile out/soong/.minibootstrap/build-globs.ninja -o out/soong/.bootstrap/build.ninja Android.bp
internal error: could not open symlink hardware/qcom/sdm845/Android.bp; its target (data/ipacfg-mgr/os_pickup.bp) cannot be opened
internal error: could not open symlink hardware/qcom/sm8150/Android.bp; its target (data/ipacfg-mgr/os_pickup.bp) cannot be opened
18:46:23 soong minibootstrap failed with: exit status 1
```
* After first commit to fix the issue and execute `repo sync && ./repo_update_sh` the second build finished quickly with new error:
```
FAILED: ninja: 'hardware/qcom/sm8150/display/display_defaults.go', needed by 'out/soong/.bootstrap/soong-display_defaults/pkg/android/soong/hardware/qcom/sm8150/display.a', missing and no known rule to make it
19:22:30 soong bootstrap failed with: exit status 1
```
* After second commit fixing missing files and syncing/updating the sources the build went through.


# The solution

Missing files are available in projects that were removed via "remove-project" record in local_manifests XML files. Adding projects back to the build directory (by removing appropriate lines from appropriate xml manifest files) solved the problem:
* ~~`<remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />`~~ (qcom.xml)
* ~~`<remove-project name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" />`~~ (untracked_hardware.xml)
* ~~`<remove-project name="platform/hardware/qcom/sm8150/display" />`~~ (untracked_hardware.xml) 


# The observation

In the file [qcom.xml](https://github.com/sonyxperiadev/local_manifests/blob/android-10.0.0_r33/qcom.xml) in [line 15](https://github.com/sonyxperiadev/local_manifests/blob/android-10.0.0_r33/qcom.xml#L15) there is a record
```
<project path="hardware/qcom/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
```
which looks like a project that was just removed in [line 7](https://github.com/sonyxperiadev/local_manifests/blob/android-10.0.0_r33/qcom.xml#L7) 
```
<remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
```
According to the Git Blame this file was modified by @jerpelea 1.5 year ago in [sdm845: add ipacfg-mgr ](https://github.com/sonyxperiadev/local_manifests/commit/b487fa2387bf6f0c61ac70768711dc53c3cd74f1) commit with comment "ipacfg-mgr is added and moved to the old location (...)" which sounds like backward compatibility. I'm not sure if path `hardware/qcom/data/ipacfg-mgr/sdm845` is in use anymore due to `hardware/qcom/sdm845/data/ipacfg-mgr` current location.

This part of untracked_hardware.xml file that I was struggling with was modified by @ix5 and @jerpelea just a couple of months ago in [untracked_hardware: Remove unused sm8150 HALs ](https://github.com/sonyxperiadev/local_manifests/commit/68785a0c52e342bbdb474ce56929cd45f37e4d42) commit.

I know these changes are not recent but any explanation will be hugely appreciated as I'm trying to understand the AOSP building system for Sony devices.


# Environment summary

* Target:
  * Device: Sony Xperia 10 (I3113)
  * Codename: kirin
  * AOSP tag: android-10.0.0_r33

* Build environment:
  * Built on Azure virtual machine
  * OS: 18.04.4 LTS (Bionic Beaver)
  * repo: 
    * version v2.7
    * launcher version 2.5
  * git 2.26.2
  * Python 3.6.9
  * GCC 8.4.0
  * 4 cores
  * 14 GB of RAM
  * 1 TB of hard disk