### PR TITLE
[LOCAL_MANIFESTS] qcom.xml: Add sound trigger HAL

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -20,6 +20,7 @@
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="q-mr1" />
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="q-mr0" />
+<project path="vendor/qcom/opensource/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/telephony" name="vendor-qcom-opensource-telephony" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />


### PR DESCRIPTION
Add the sound trigger HAL to vendor/qcom/opensource/st-hal
now that it compiles and can run just fine.

Test: Build OK
Depends on https://github.com/sonyxperiadev/vendor-qcom-opensource-audio-hal-st-hal/pull/1