### PR TITLE
[DNM] untracked/qcom: switch to own gps hal

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -2,11 +2,9 @@
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 
-<remove-project name="platform/hardware/qcom/gps" />
-<remove-project name="platform/hardware/qcom/sdm845/gps" />
 <remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
 
-<project path="hardware/qcom/gps" name="platform/hardware/qcom/sdm845/gps" remote="aosp" groups="qcom_sdm845" />
+<project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 
 <project path="vendor/qcom/opensource/display" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/media/sm8150" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
@@ -19,7 +17,7 @@
 <project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="q-mr1" />
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
-<project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="q-mr0" />
+<project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/telephony" name="vendor-qcom-opensource-telephony" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remove-project name="platform/hardware/qcom/display" />
+    <remove-project name="platform/hardware/qcom/gps" />
     <remove-project name="platform/hardware/qcom/media" />
     <remove-project name="platform/hardware/qcom/msm8x09" />
     <remove-project name="platform/hardware/qcom/msm8960" />
@@ -12,6 +13,7 @@
     <remove-project name="platform/hardware/qcom/msm8x84" />
     <remove-project name="platform/hardware/qcom/sdm845/bt" />
     <remove-project name="platform/hardware/qcom/sdm845/display" />
+    <remove-project name="platform/hardware/qcom/sdm845/gps" />
     <remove-project name="platform/hardware/qcom/sdm845/media" />
     <remove-project name="platform/hardware/qcom/sdm845/thermal" />
     <remove-project name="platform/hardware/qcom/sdm845/vr" />


### PR DESCRIPTION
Instead of relying on aosp gps hals, which are not always in sync with oss location, switch to using hal from caf.
Also move the hal to vendor to make it inline with the other hals.