### PR TITLE
[LOCAL_MANIFESTS] vendor-qcom-opensource-wlan: Update qcacld driver to 8.1 branch

### DIFF
--- a/LA.UM.7.1.r1.xml
+++ b/LA.UM.7.1.r1.xml
@@ -7,7 +7,7 @@
 <project path="kernel/sony/msm-4.14/kernel/techpack/audio" name="kernel-techpack-audio" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="kernel/sony/msm-4.14/kernel/techpack/data-kernel" name="kernel-techpack-data-kernel" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="kernel/sony/msm-4.14/kernel/arch/arm64/configs/sony" name="kernel-defconfig" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
-<project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
-<project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
-<project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
+<project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+<project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+<project path="kernel/sony/msm-4.14/kernel/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 </manifest>


### PR DESCRIPTION
All our phones have been tested to deliver similar or better WiFi
performance on the sm8150 8.1 branches, and the newer tag is a
requirement for Seine.

Together with:
https://github.com/sonyxperiadev/kernel/pull/2292
https://github.com/sonyxperiadev/vendor-qcom-opensource-wlan-qcacld-3.0/pull/26
