### PR TITLE
[android-10.0.0_r41] external: move exfat support tooling from relan to exfatprogs

### DIFF
--- a/external.xml
+++ b/external.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-<remote name="relan" fetch="https://github.com/relan/" />
-<project path="vendor/external/exfat" name="exfat" groups="device" remote="relan" revision="68ba243d5d15854bebe61514217bcff2345d3614" />
+<remote name="exfatprogs" fetch="https://github.com/exfatprogs/" />
+<project path="vendor/external/exfatprogs" name="exfatprogs" groups="device" remote="exfatprogs" revision="refs/tags/1.0.4" />
 </manifest>


### PR DESCRIPTION
As requested, resubmitted against the current branch and avoid clashing in the
destination directories: it will delete the old exfat directory and create the new exfatprogs:

```
$ repo sync -j8 --current-branch --no-tags
Fetching projects:   1% (11/707)
 . . .
vendor/external/exfat: Deleting obsolete checkout.
. . .
Checking out projects: 100% (707/707), done.
repo sync has finished successfully.
$ ls vendor/external/ | grep exfat
exfatprogs
```

(Proper history of this PR can be checked at https://github.com/sonyxperiadev/local_manifests/pull/103).