### PR TITLE
Update manifest for Android R

### DIFF
--- a/untracked.xml
+++ b/untracked.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remove-project name="kernel/tests" />
-    <remove-project name="platform/external/nos/host/generic" />
     <remove-project name="platform/prebuilts/android-emulator" />
     <remove-project name="platform/prebuilts/qemu-kernel" />
 </manifest>

--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -31,16 +31,14 @@
     <remove-project name="device/google/crosshatch-kernel" />
     <remove-project name="device/google/crosshatch-sepolicy" />
     <remove-project name="device/google/cuttlefish" />
-    <remove-project name="device/google/cuttlefish_common" />
     <remove-project name="device/google/cuttlefish_kernel" />
     <remove-project name="device/google/cuttlefish_vmm" />
     <remove-project name="device/google/fuchsia" />
-    <remove-project name="device/google/marlin" />
-    <remove-project name="device/google/marlin-kernel" />
     <remove-project name="device/google/muskie" />
     <remove-project name="device/google/taimen" />
     <remove-project name="device/google/vrservices" />
     <remove-project name="device/google/wahoo" />
+    <remove-project name="device/google/trout" />
     <remove-project name="device/google/wahoo-kernel" />
     <remove-project name="device/linaro/bootloader/arm-trusted-firmware" />
     <remove-project name="device/linaro/bootloader/edk2" />
@@ -49,6 +47,8 @@
     <remove-project name="device/linaro/hikey-kernel" />
     <remove-project name="device/linaro/poplar" />
     <remove-project name="device/linaro/poplar-kernel" />
+    <remove-project name="device/linaro/dragonboard" />
+    <remove-project name="device/linaro/dragonboard-kernel" />
     <!-- Necessary for apns -->
     <!--<remove-project name="device/sample" />-->
     <remove-project name="device/ti/beagle-x15" />

--- a/untracked_packages.xml
+++ b/untracked_packages.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <!-- Not building for cars... -->
+    <remove-project name="platform/packages/apps/Car/Calendar" />
     <remove-project name="platform/packages/apps/Car/Cluster" />
+    <remove-project name="platform/packages/apps/Car/CompanionDeviceSupport" />
     <remove-project name="platform/packages/apps/Car/Dialer" />
     <remove-project name="platform/packages/apps/Car/Hvac" />
     <remove-project name="platform/packages/apps/Car/LatinIME" />
     <remove-project name="platform/packages/apps/Car/Launcher" />
-    <remove-project name="platform/packages/apps/Car/LensPicker" />
     <remove-project name="platform/packages/apps/Car/LinkViewer" />
     <!-- PackageInstaller depends on car-list, which is in the libs: -->
     <!--<remove-project name="platform/packages/apps/Car/libs" />-->
@@ -18,11 +19,9 @@
     depends on the Notification package.
     -->
     <!-- <remove-project name="platform/packages/apps/Car/Notification" /> -->
-    <remove-project name="platform/packages/apps/Car/Overview" />
     <remove-project name="platform/packages/apps/Car/Radio" />
+    <remove-project name="platform/packages/apps/Car/RotaryController" />
     <remove-project name="platform/packages/apps/Car/Settings" />
-    <remove-project name="platform/packages/apps/Car/Stream" />
     <remove-project name="platform/packages/apps/Car/SystemUpdater" />
-    <remove-project name="platform/packages/apps/Car/externallibs" />
     <remove-project name="platform/packages/apps/Car/tests" />
 </manifest>


### PR DESCRIPTION
These changes are necessary to get a working build. We should likely remove the remaining manufacturers/devices from `device/` as well.

@jerpelea how/when do you want to branch out for R?
