### PR TITLE
oss.xml: Drop interfaces repo

### DIFF
--- a/oss.xml
+++ b/oss.xml
@@ -3,7 +3,6 @@
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 <project path="vendor/oss/cash"  name="vendor-sony-oss-cash" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="master" />
-<project path="vendor/oss/interfaces"  name="vendor-oss-interfaces" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/json-c"  name="json-c" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/opentelephony" name="SonyOpenTelephony" groups="device" remote="sony" revision="master" />


### PR DESCRIPTION
We sadly no longer can provide support for all the legacy devices.
Thus lets delete this repo as it wont be longer required.
Also this repo just contains USB HAL that for things that
dont support /sys/class/dual_role_usb