### PR TITLE
vendor.qcom.opensource.bluetooth: set to p-mr1 branch

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -15,7 +15,7 @@
 <project path="hardware/qcom/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
 
 <project path="vendor/qcom/opensource/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
-<project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
+<project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="p-mr1" />
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="p-mr0" />
 <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />


### PR DESCRIPTION
The master branch of vendor.qcom.opensource.bluetooth has a patch to remove references to libhidltransport, which was still present in android-9.0.0_r46. This causes the following error when trying to build AOSP:

```
system/libhidl/transport/include/hidl/LegacySupport.h:69: error: undefined reference to 'android::hardware::configureRpcThreadpool(unsigned long, bool)'
system/libhidl/transport/include/hidl/LegacySupport.h:76: error: undefined reference to 'android::hardware::joinRpcThreadpool()'
```

See https://github.com/sonyxperiadev/vendor-qcom-opensource-bluetooth/issues/3 and https://github.com/sonyxperiadev/bug_tracker/issues/474