### PR TITLE
[11_r4] nxp: Switch to new github repository

### DIFF
--- a/nxp.xml
+++ b/nxp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-<remote name="NXP" fetch="https://github.com/NXPNFCProject/" />
+<remote name="NXP" fetch="https://github.com/NXP/" />
 <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
-<project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="NXP" revision="master" />
+<project path="vendor/nxp/NXPNFCC_FW" name="nfc-NXPNFCC_FW" groups="device" remote="NXP" revision="master" />
 </manifest>


### PR DESCRIPTION
The NXPNFCProject is deprecated, so switch to new repository