### PR TITLE
[master] Untrack unused AOSP QCOM repos

### DIFF
--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -3,6 +3,7 @@
     <remove-project name="platform/hardware/broadcom/wlan" />
     <remove-project name="platform/hardware/qcom/audio" />
     <remove-project name="platform/hardware/qcom/camera" />
+    <remove-project name="platform/hardware/qcom/data/ipacfg-mgr" />
     <remove-project name="platform/hardware/qcom/display" />
     <remove-project name="platform/hardware/qcom/gps" />
     <remove-project name="platform/hardware/qcom/media" />

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -2,6 +2,7 @@
 <manifest>
     <remove-project name="platform/hardware/broadcom/wlan" />
     <remove-project name="platform/hardware/qcom/audio" />
+    <remove-project name="platform/hardware/qcom/camera" />
     <remove-project name="platform/hardware/qcom/display" />
     <remove-project name="platform/hardware/qcom/gps" />
     <remove-project name="platform/hardware/qcom/media" />


### PR DESCRIPTION
This will be needed in order to disable `TARGET_BOARD_AUTO`
as some of this repos are picked wrongly by `yoshino `after the removal.

This needs to be specially tested on `yoshino`, for which I don't have availability.