### PR TITLE
[R] Remove broadcom wlan repo.

### DIFF
--- a/broadcom.xml
+++ b/broadcom.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-<project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" groups="device" remote="sony" revision="master" />
-</manifest>


### PR DESCRIPTION
As of Android 11 we don't support any Broadcom WiFi enabled devices thus lets remove the repos.

This needs to be completely tested that it doesn't break anything.