### PR TITLE
hardware: Untrack sm7250 repos

### DIFF
--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -20,6 +20,9 @@
     <remove-project name="platform/hardware/qcom/sdm845/media" />
     <remove-project name="platform/hardware/qcom/sdm845/thermal" />
     <remove-project name="platform/hardware/qcom/sdm845/vr" />
+    <remove-project name="platform/hardware/qcom/sm7250/display" />
+    <remove-project name="platform/hardware/qcom/sm7250/gps" />
+    <remove-project name="platform/hardware/qcom/sm7250/media" />
     <remove-project name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" />
     <remove-project name="platform/hardware/qcom/sm8150/display" />
     <remove-project name="platform/hardware/qcom/sm8150/gps" />


### PR DESCRIPTION
Android 11 r29 tags added some new HALs that we don't use.

---

Note that we also seem to have `sm7150` and `sm8150p` in-tree, both unused. Should we untrack those as well?
