### PR TITLE
[local_manifests] [R r32] untracked_devices: Remove bramble/redfin kernels for 11.0.0_r32

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -25,7 +25,6 @@
     <remove-project name="device/google/bonito-kernel" />
     <remove-project name="device/google/bonito-sepolicy" />
     <remove-project name="device/google/bramble" />
-    <remove-project name="device/google/bramble-kernel" />
     <remove-project name="device/google/bramble-sepolicy" />
     <remove-project name="device/google/contexthub" />
     <remove-project name="device/google/coral" />
@@ -41,7 +40,6 @@
     <remove-project name="device/google/redbull" />
     <remove-project name="device/google/redbull-sepolicy" />
     <remove-project name="device/google/redfin" />
-    <remove-project name="device/google/redfin-kernel" />
     <remove-project name="device/google/redfin-sepolicy" />
     <remove-project name="device/google/sunfish" />
     <remove-project name="device/google/sunfish-kernel" />


### PR DESCRIPTION
AOSP dropped the kernel for these devices on r32, presumably while moving to `kernel/prebuilts/...`.

---

@jerpelea please create an `android-11.0.0_r32` branch and update the target branch before merging this!

Disclaimer: r32 was not build/run-tested yet, this only gets my mirror to sync properly against it.
