### PR TITLE
[local_manifests] [R-r32/master] untracked_devices: Untrack redbull-kernel

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -38,6 +38,7 @@
     <remove-project name="device/google/cuttlefish_vmm" />
     <remove-project name="device/google/fuchsia" />
     <remove-project name="device/google/redbull" />
+    <remove-project name="device/google/redbull-kernel" />
     <remove-project name="device/google/redbull-sepolicy" />
     <remove-project name="device/google/redfin" />
     <remove-project name="device/google/redfin-sepolicy" />


### PR DESCRIPTION
This was missed during the r32 rebase.

Fixes: 0b3c5a8 ("untracked_devices: Remove bramble/redfin kernels for 11.0.0_r32")
