### PR TITLE
qcom: Point audio HALs to aosp/LA.UM.9.12.r1

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -16,8 +16,8 @@
 <project path="vendor/qcom/opensource/media/sm8150" name="hardware-qcom-media-sm8150" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
 
-<project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="r-mr1" />
-<project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+<project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="r-mr1" />
 <project path="vendor/qcom/opensource/telephony" name="vendor-qcom-opensource-telephony" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />


### PR DESCRIPTION
The `r-mr1` branch contains an older failed port attempt on top of 9.11 branches, while the actual development efforts have been made on `aosp/LA.UM.9.12.r1` (though that branch is based on 9.15 KAMORTA).

The st-hal has been updated to newer tags to follow suit.
