### PR TITLE
[local_manifests] [11 r1+] Untrack external/linux-kselftest

### DIFF
--- a/untracked_external.xml
+++ b/untracked_external.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remove-project name="platform/external/linux-kselftest" />
+</manifest>


### PR DESCRIPTION
This repo exists since at least Android 11 r1 but just showed up on my list as downloading a large swath of objects when syncing r37.  Since we don't use this anywhere and it doesn't appear to be build-time requirement, get rid of it and save ourselves some space.

---

@jerpelea please do your rebasing magic :)
