### PR TITLE
[S] LA.UM.9.12: Add kernel video-driver repo

### DIFF
--- a/LA.UM.9.12.r1.xml
+++ b/LA.UM.9.12.r1.xml
@@ -8,6 +8,7 @@
 <project path="kernel/sony/msm-4.19/kernel/techpack/camera" name="kernel-techpack-camera" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="kernel/sony/msm-4.19/kernel/techpack/data-kernel" name="kernel-techpack-data-kernel" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="kernel/sony/msm-4.19/kernel/techpack/display" name="kernel-techpack-display-driver" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="kernel/sony/msm-4.19/kernel/techpack/video" name="kernel-techpack-video" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="kernel/sony/msm-4.19/kernel/arch/arm64/configs/sony" name="kernel-defconfig" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="kernel/sony/msm-4.19/kernel/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="kernel/sony/msm-4.19/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />


### PR DESCRIPTION
Don't merge this yet! Edo is doing happy (albeit eating tons of power) on software encoding/decoding, but with vidc camera recording crashes in various ways (buffer allocation failures, segfaults deep in the CHI). This should at least get us started on a common debugging ground.