### PR TITLE
Initial manifest changes for Android S

### DIFF
--- a/untracked.xml
+++ b/untracked.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remove-project name="kernel/tests" />
     <remove-project name="platform/prebuilts/android-emulator" />
     <remove-project name="platform/prebuilts/qemu-kernel" />
 </manifest>

--- a/untracked_darwin.xml
+++ b/untracked_darwin.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+    <remove-project name="platform/prebuilts/bazel/darwin-x86_64" />
     <remove-project name="platform/prebuilts/clang/host/darwin-x86" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" />
-    <remove-project name="platform/prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" />
     <remove-project name="platform/prebuilts/gdb/darwin-x86" />
     <remove-project name="platform/prebuilts/go/darwin-x86" />

--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -18,9 +18,14 @@
     <remove-project name="device/generic/qemu" />
     <remove-project name="device/generic/trusty" />
     <remove-project name="device/generic/uml" />
+    <!-- Graphics Streaming Kit: Ued in ie rutabaga_gfx -->
+    <!-- <remove-project name="device/generic/vulkan-cereal" /> -->
     <remove-project name="device/generic/x86" />
     <remove-project name="device/generic/x86_64" />
     <remove-project name="device/google/atv" />
+    <remove-project name="device/google/barbet" />
+    <remove-project name="device/google/barbet-kernel" />
+    <remove-project name="device/google/barbet-sepolicy" />
     <remove-project name="device/google/bonito" />
     <remove-project name="device/google/bonito-kernel" />
     <remove-project name="device/google/bonito-sepolicy" />
@@ -33,9 +38,9 @@
     <remove-project name="device/google/crosshatch" />
     <remove-project name="device/google/crosshatch-kernel" />
     <remove-project name="device/google/crosshatch-sepolicy" />
-    <remove-project name="device/google/cuttlefish" />
-    <remove-project name="device/google/cuttlefish_kernel" />
-    <remove-project name="device/google/cuttlefish_vmm" />
+    <!-- Device repo provides core libraries for ie. microdroid -->
+    <!-- <remove-project name="device/google/cuttlefish" /> -->
+    <!-- <remove-project name="device/google/cuttlefish_prebuilts" /> -->
     <remove-project name="device/google/fuchsia" />
     <remove-project name="device/google/redbull" />
     <remove-project name="device/google/redbull-kernel" />
@@ -48,9 +53,6 @@
     <remove-project name="device/google/trout" />
     <remove-project name="device/google/vrservices" />
     <remove-project name="device/google_car" />
-    <remove-project name="device/linaro/bootloader/OpenPlatformPkg" />
-    <remove-project name="device/linaro/bootloader/arm-trusted-firmware" />
-    <remove-project name="device/linaro/bootloader/edk2" />
     <remove-project name="device/linaro/dragonboard" />
     <remove-project name="device/linaro/dragonboard-kernel" />
     <remove-project name="device/linaro/hikey" />

--- a/untracked_kernel.xml
+++ b/untracked_kernel.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remove-project name="kernel/prebuilts/4.19/arm64" />
+    <!-- Keep for virtualization tests -->
+    <!-- <remove-project name="kernel/prebuilts/5.10/arm64" /> -->
+    <remove-project name="kernel/prebuilts/5.10/x86-64" />
+    <remove-project name="kernel/prebuilts/5.4/arm64" />
+    <remove-project name="kernel/prebuilts/5.4/x86-64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/4.19/arm64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/4.19/x86-64" />
+    <!-- Keep for microdroid and all the dependent virtualization packages -->
+    <!-- <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.10/arm64" /> -->
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.10/x86-64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.4/arm64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.4/x86-64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/mainline/arm64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/mainline/x86-64" />
+    <remove-project name="kernel/prebuilts/mainline/arm64" />
+    <remove-project name="kernel/tests" />
 </manifest>

--- a/untracked_packages.xml
+++ b/untracked_packages.xml
@@ -3,24 +3,25 @@
     <!-- Not building for cars... -->
     <remove-project name="platform/packages/apps/Car/Calendar" />
     <remove-project name="platform/packages/apps/Car/Cluster" />
+    <remove-project name="platform/packages/apps/Car/DebuggingRestrictionController" />
     <remove-project name="platform/packages/apps/Car/Dialer" />
     <remove-project name="platform/packages/apps/Car/Hvac" />
     <remove-project name="platform/packages/apps/Car/LatinIME" />
     <remove-project name="platform/packages/apps/Car/Launcher" />
     <remove-project name="platform/packages/apps/Car/LinkViewer" />
-    <!-- PackageInstaller depends on car-list, which is in the libs: -->
-    <!--<remove-project name="platform/packages/apps/Car/libs" />-->
     <remove-project name="platform/packages/apps/Car/LocalMediaPlayer" />
     <remove-project name="platform/packages/apps/Car/Media" />
     <remove-project name="platform/packages/apps/Car/Messenger" />
-    <!--
-    frameworks/base/packages/CarSystemUI (which cannot be untracked)
-    depends on the Notification package.
-    -->
-    <!-- <remove-project name="platform/packages/apps/Car/Notification" /> -->
+    <remove-project name="platform/packages/apps/Car/Notification" />
+    <remove-project name="platform/packages/apps/Car/Provision" />
     <remove-project name="platform/packages/apps/Car/Radio" />
-    <remove-project name="platform/packages/apps/Car/RotaryController" />
+    <!-- Used by cts tests -->
+    <!-- <remove-project name="platform/packages/apps/Car/RotaryController" /> -->
     <remove-project name="platform/packages/apps/Car/Settings" />
+    <remove-project name="platform/packages/apps/Car/SettingsIntelligence" />
+    <remove-project name="platform/packages/apps/Car/SystemUI" />
     <remove-project name="platform/packages/apps/Car/SystemUpdater" />
+    <!-- Various packages depend on carg-ui-lib: -->
+    <!-- <remove-project name="platform/packages/apps/Car/libs" /> -->
     <remove-project name="platform/packages/apps/Car/tests" />
 </manifest>


### PR DESCRIPTION
- darwin: Ignore bazel prebuilt and remove mips64el toolchain for S
- untracked_kernel: Update prebuilt removal for Android S
- untracked_devices: Update for Android S
- untracked_packages: Update for Android S
