### PR TITLE
[R/S] qcom: Track our fork of the CAF bootctrl 1.1 HAL

### DIFF
--- a/LA.UM.9.14.r1.xml
+++ b/LA.UM.9.14.r1.xml
@@ -8,6 +8,8 @@
 <project path="kernel/sony/msm-5.4/kernel/techpack/camera" name="kernel-techpack-camera" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="kernel/sony/msm-5.4/kernel/techpack/dataipa" name="kernel-techpack-dataipa" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="kernel/sony/msm-5.4/kernel/techpack/display" name="kernel-techpack-display-driver" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/techpack/video" name="kernel-techpack-video" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/techpack/sched" name="kernel-techpack-sched" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="kernel/sony/msm-5.4/kernel/arch/arm64/configs/sony" name="kernel-defconfig" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="kernel/sony/msm-5.4/kernel/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="kernel/sony/msm-5.4/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />

--- a/LA.UM.9.14.r1.xml
+++ b/LA.UM.9.14.r1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+<project path="kernel/sony/msm-5.4/common-headers" name="kernel-sony-msm-5.4-headers" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/common-kernel" name="kernel-sony-msm-5.4-common" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" clone-depth="1"/>
+<project path="kernel/sony/msm-5.4/kernel" name="kernel" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/techpack/audio" name="kernel-techpack-audio" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/techpack/camera" name="kernel-techpack-camera" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/techpack/dataipa" name="kernel-techpack-dataipa" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/techpack/display" name="kernel-techpack-display-driver" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/arch/arm64/configs/sony" name="kernel-defconfig" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="kernel/sony/msm-5.4/kernel/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+</manifest>

--- a/devices.xml
+++ b/devices.xml
@@ -15,12 +15,6 @@
 <project path="device/sony/kirin" name="device-sony-kirin" groups="device" remote="sony" revision="s-mr1" />
 <project path="device/sony/mermaid" name="device-sony-mermaid" groups="device" remote="sony" revision="s-mr1" />
 
-<!--msm8998-->
-<project path="device/sony/yoshino" name="device-sony-yoshino" groups="device" remote="sony" revision="s-mr1" />
-<project path="device/sony/lilac" name="device-sony-lilac" groups="device" remote="sony" revision="s-mr1" />
-<project path="device/sony/maple" name="device-sony-maple" groups="device" remote="sony" revision="s-mr1" />
-<project path="device/sony/poplar" name="device-sony-poplar" groups="device" remote="sony" revision="s-mr1" />
-
 <!--sdm845-->
 <project path="device/sony/tama" name="device-sony-tama" groups="device" remote="sony" revision="s-mr1" />
 <project path="device/sony/akari" name="device-sony-akari" groups="device" remote="sony" revision="s-mr1" />

--- a/devices.xml
+++ b/devices.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
-<project path="device/sony/sepolicy" name="device-sony-sepolicy" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/common" name="device-sony-common" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/sepolicy" name="device-sony-sepolicy" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/common" name="device-sony-common" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sdm630-->
-<project path="device/sony/nile" name="device-sony-nile" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/discovery" name="device-sony-discovery" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/pioneer" name="device-sony-pioneer" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/voyager" name="device-sony-voyager" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/nile" name="device-sony-nile" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/discovery" name="device-sony-discovery" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pioneer" name="device-sony-pioneer" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/voyager" name="device-sony-voyager" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sdm630-->
-<project path="device/sony/ganges" name="device-sony-ganges" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/kirin" name="device-sony-kirin" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/mermaid" name="device-sony-mermaid" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/ganges" name="device-sony-ganges" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/kirin" name="device-sony-kirin" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/mermaid" name="device-sony-mermaid" groups="device" remote="sony" revision="s-mr1" />
 
 <!--msm8998-->
-<project path="device/sony/yoshino" name="device-sony-yoshino" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/lilac" name="device-sony-lilac" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/maple" name="device-sony-maple" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/poplar" name="device-sony-poplar" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/yoshino" name="device-sony-yoshino" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/lilac" name="device-sony-lilac" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/maple" name="device-sony-maple" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/poplar" name="device-sony-poplar" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sdm845-->
-<project path="device/sony/tama" name="device-sony-tama" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/akari" name="device-sony-akari" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/akatsuki" name="device-sony-akatsuki" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/apollo" name="device-sony-apollo" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/tama" name="device-sony-tama" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/akari" name="device-sony-akari" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/akatsuki" name="device-sony-akatsuki" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/apollo" name="device-sony-apollo" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sm8150-->
-<project path="device/sony/kumano" name="device-sony-kumano" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/bahamut" name="device-sony-bahamut" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/griffin" name="device-sony-griffin" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/kumano" name="device-sony-kumano" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/bahamut" name="device-sony-bahamut" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/griffin" name="device-sony-griffin" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sm6125-->
-<project path="device/sony/seine" name="device-sony-seine" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/pdx201" name="device-sony-pdx201" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/seine" name="device-sony-seine" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pdx201" name="device-sony-pdx201" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sm6350-->
-<project path="device/sony/lena" name="device-sony-lena" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/pdx213" name="device-sony-pdx213" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/lena" name="device-sony-lena" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pdx213" name="device-sony-pdx213" groups="device" remote="sony" revision="s-mr1" />
 
 <!--sm8250-->
-<project path="device/sony/edo" name="device-sony-edo" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/pdx203" name="device-sony-pdx203" groups="device" remote="sony" revision="r-mr1" />
-<project path="device/sony/pdx206" name="device-sony-pdx206" groups="device" remote="sony" revision="r-mr1" />
+<project path="device/sony/edo" name="device-sony-edo" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pdx203" name="device-sony-pdx203" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pdx206" name="device-sony-pdx206" groups="device" remote="sony" revision="s-mr1" />
 </manifest>

--- a/devices.xml
+++ b/devices.xml
@@ -38,4 +38,9 @@
 <project path="device/sony/edo" name="device-sony-edo" groups="device" remote="sony" revision="s-mr1" />
 <project path="device/sony/pdx203" name="device-sony-pdx203" groups="device" remote="sony" revision="s-mr1" />
 <project path="device/sony/pdx206" name="device-sony-pdx206" groups="device" remote="sony" revision="s-mr1" />
+
+<!--sm8350-->
+<project path="device/sony/sagami" name="device-sony-sagami" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pdx214" name="device-sony-pdx214" groups="device" remote="sony" revision="s-mr1" />
+<project path="device/sony/pdx215" name="device-sony-pdx215" groups="device" remote="sony" revision="s-mr1" />
 </manifest>

--- a/oss.xml
+++ b/oss.xml
@@ -13,7 +13,7 @@
 <project path="vendor/oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/transpower" name="transpower" groups="device" remote="sony" revision="master" />
 <project path="packages/apps/ExtendedSettings" name="packages_apps_ExtendedSettings" groups="device" remote="sony" revision="r-mr1" />
-<project path="vendor/oss/repo_update" name="repo_update" groups="device" remote="sony" revision="android-11.0.0_r1">
+<project path="vendor/oss/repo_update" name="repo_update" groups="device" remote="sony" revision="android-12.0.0_r2">
     <linkfile src="repo_update.sh" dest="repo_update.sh" />
 </project>
 </manifest>

--- a/oss.xml
+++ b/oss.xml
@@ -12,7 +12,7 @@
 <project path="vendor/oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/transpower" name="transpower" groups="device" remote="sony" revision="master" />
-<project path="packages/apps/ExtendedSettings" name="packages_apps_ExtendedSettings" groups="device" remote="sony" revision="r-mr1" />
+<project path="packages/apps/ExtendedSettings" name="packages_apps_ExtendedSettings" groups="device" remote="sony" revision="s-mr1" />
 <project path="vendor/oss/repo_update" name="repo_update" groups="device" remote="sony" revision="android-12.0.0_r2">
     <linkfile src="repo_update.sh" dest="repo_update.sh" />
 </project>

--- a/oss.xml
+++ b/oss.xml
@@ -5,7 +5,7 @@
 <project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/json-c"  name="json-c" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
-<project path="vendor/oss/opentelephony" name="SonyOpenTelephony" groups="device" remote="sony" revision="r-mr1" />
+<project path="vendor/oss/opentelephony" name="SonyOpenTelephony" groups="device" remote="sony" revision="s-mr1" />
 <project path="vendor/oss/qcrilam"  name="QcRilAm" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/release-keys" name="release-keys" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/simdetect" name="vendor-sony-oss-simdetect" groups="device" remote="sony" revision="master" />

--- a/qcom-legacy.xml
+++ b/qcom-legacy.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+
+<project path="vendor/qcom/opensource/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.8.11.r1" />
+
+<project path="vendor/qcom/opensource/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
+
+</manifest>

--- a/qcom-sm8150.xml
+++ b/qcom-sm8150.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+
+<project path="vendor/qcom/opensource/display/sm8150" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+
+<project path="vendor/qcom/opensource/media/sm8150" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
+
+<project path="vendor/qcom/opensource/display-commonsys-intf/sm8150" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1_r-mr1" />
+</manifest>

--- a/qcom-sm8150.xml
+++ b/qcom-sm8150.xml
@@ -3,8 +3,7 @@
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 
 <project path="vendor/qcom/opensource/display/sm8150" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
-
+<project path="vendor/qcom/opensource/display-commonsys-intf/sm8150" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1_r-mr1" />
 <project path="vendor/qcom/opensource/media/sm8150" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 
-<project path="vendor/qcom/opensource/display-commonsys-intf/sm8150" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1_r-mr1" />
 </manifest>

--- a/qcom-sm8250.xml
+++ b/qcom-sm8250.xml
@@ -3,7 +3,7 @@
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 
 <project path="vendor/qcom/opensource/display/sm8250" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
-
+<project path="vendor/qcom/opensource/display-commonsys-intf/sm8250" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="vendor/qcom/opensource/media/sm8250" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 
 </manifest>

--- a/qcom-sm8250.xml
+++ b/qcom-sm8250.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+
+<project path="vendor/qcom/opensource/display/sm8250" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+
+<project path="vendor/qcom/opensource/media/sm8250" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+
+</manifest>

--- a/qcom-sm8350.xml
+++ b/qcom-sm8350.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+
+<project path="vendor/qcom/opensource/display/sm8350" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="vendor/qcom/opensource/media/sm8350" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+
+</manifest>

--- a/qcom-sm8350.xml
+++ b/qcom-sm8350.xml
@@ -3,6 +3,6 @@
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 
 <project path="vendor/qcom/opensource/display/sm8350" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="vendor/qcom/opensource/display-commonsys-intf/sm8350" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="vendor/qcom/opensource/media/sm8350" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
-
 </manifest>

--- a/qcom.xml
+++ b/qcom.xml
@@ -5,8 +5,8 @@
 <remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
 <project path="vendor/qcom/opensource/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
 
-<project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
-<project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
 <project path="vendor/qcom/opensource/display-commonsys-intf/sm8250" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 

--- a/qcom.xml
+++ b/qcom.xml
@@ -5,20 +5,10 @@
 <remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
 <project path="vendor/qcom/opensource/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
 
-<project path="vendor/qcom/opensource/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.8.11.r1" />
-
 <project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 
-<project path="vendor/qcom/opensource/display/sm8150" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1_r-mr1" />
-<project path="vendor/qcom/opensource/display-commonsys-intf/sm8150" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1_r-mr1" />
-
-<project path="vendor/qcom/opensource/display/sm8250" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="vendor/qcom/opensource/display-commonsys-intf/sm8250" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
-
-<project path="vendor/qcom/opensource/media/sdm660-libion" name="hardware-qcom-media" groups="device" remote="sony" revision="aosp/LA.UM.8.2.1.r1" />
-<project path="vendor/qcom/opensource/media/sm8150" name="hardware-qcom-media-sm8150" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
-<project path="vendor/qcom/opensource/media/sm8250" name="hardware-qcom-media-sm8150" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 
 <project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />

--- a/qcom.xml
+++ b/qcom.xml
@@ -8,8 +8,6 @@
 <project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
-<project path="vendor/qcom/opensource/display-commonsys-intf/sm8250" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
-
 <project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 <project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 

--- a/qcom.xml
+++ b/qcom.xml
@@ -3,7 +3,7 @@
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 
 <remove-project name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" />
-<project path="vendor/qcom/opensource/data/ipacfg-mgr/sdm845" name="platform/hardware/qcom/sdm845/data/ipacfg-mgr" groups="qcom_sdm845" remote="aosp" />
+<project path="vendor/qcom/opensource/data/ipacfg-mgr" name="vendor-qcom-opensource-data-ipa-cfg-mgr" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
 <project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />

--- a/qcom.xml
+++ b/qcom.xml
@@ -20,9 +20,11 @@
 
 <project path="vendor/qcom/opensource/core-utils" name="vendor-qcom-opensource-core-utils" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
-<project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
+
+<project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
+<project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
 
 <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 </manifest>

--- a/qcom.xml
+++ b/qcom.xml
@@ -8,15 +8,15 @@
 <project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
-<project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
-<project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
+<project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="r-mr1" />
-<project path="vendor/qcom/opensource/telephony" name="vendor-qcom-opensource-telephony" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/telephony" name="vendor-qcom-opensource-telephony" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
-<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
-<project path="vendor/qcom/opensource/usb" name="vendor-qcom-opensource-usb" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/usb" name="vendor-qcom-opensource-usb" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 
 <project path="vendor/qcom/opensource/core-utils" name="vendor-qcom-opensource-core-utils" groups="device" remote="sony" revision="aosp/LA.UM.8.1.r1" />
 <project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
@@ -24,5 +24,5 @@
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
 
-<project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="aosp/LA.UM.9.12.r1" />
+<project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="aosp/LA.UM.9.14.r1" />
 </manifest>

--- a/untracked.xml
+++ b/untracked.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remove-project name="kernel/tests" />
     <remove-project name="platform/prebuilts/android-emulator" />
     <remove-project name="platform/prebuilts/qemu-kernel" />
 </manifest>

--- a/untracked_darwin.xml
+++ b/untracked_darwin.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+    <remove-project name="platform/prebuilts/bazel/darwin-x86_64" />
     <remove-project name="platform/prebuilts/clang/host/darwin-x86" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1" />
-    <remove-project name="platform/prebuilts/gcc/darwin-x86/mips/mips64el-linux-android-4.9" />
     <remove-project name="platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9" />
     <remove-project name="platform/prebuilts/gdb/darwin-x86" />
     <remove-project name="platform/prebuilts/go/darwin-x86" />

--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -18,9 +18,14 @@
     <remove-project name="device/generic/qemu" />
     <remove-project name="device/generic/trusty" />
     <remove-project name="device/generic/uml" />
+    <!-- Graphics Streaming Kit: Ued in ie rutabaga_gfx -->
+    <!-- <remove-project name="device/generic/vulkan-cereal" /> -->
     <remove-project name="device/generic/x86" />
     <remove-project name="device/generic/x86_64" />
     <remove-project name="device/google/atv" />
+    <remove-project name="device/google/barbet" />
+    <remove-project name="device/google/barbet-kernel" />
+    <remove-project name="device/google/barbet-sepolicy" />
     <remove-project name="device/google/bonito" />
     <remove-project name="device/google/bonito-kernel" />
     <remove-project name="device/google/bonito-sepolicy" />
@@ -33,9 +38,9 @@
     <remove-project name="device/google/crosshatch" />
     <remove-project name="device/google/crosshatch-kernel" />
     <remove-project name="device/google/crosshatch-sepolicy" />
-    <remove-project name="device/google/cuttlefish" />
-    <remove-project name="device/google/cuttlefish_kernel" />
-    <remove-project name="device/google/cuttlefish_vmm" />
+    <!-- Device repo provides core libraries for ie. microdroid -->
+    <!-- <remove-project name="device/google/cuttlefish" /> -->
+    <!-- <remove-project name="device/google/cuttlefish_prebuilts" /> -->
     <remove-project name="device/google/fuchsia" />
     <remove-project name="device/google/redbull" />
     <remove-project name="device/google/redbull-kernel" />
@@ -48,9 +53,6 @@
     <remove-project name="device/google/trout" />
     <remove-project name="device/google/vrservices" />
     <remove-project name="device/google_car" />
-    <remove-project name="device/linaro/bootloader/OpenPlatformPkg" />
-    <remove-project name="device/linaro/bootloader/arm-trusted-firmware" />
-    <remove-project name="device/linaro/bootloader/edk2" />
     <remove-project name="device/linaro/dragonboard" />
     <remove-project name="device/linaro/dragonboard-kernel" />
     <remove-project name="device/linaro/hikey" />

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -2,15 +2,16 @@
 <manifest>
     <remove-project name="platform/hardware/broadcom/wlan" />
     <remove-project name="platform/hardware/qcom/audio" />
+    <remove-project name="platform/hardware/qcom/bootctrl" />
     <remove-project name="platform/hardware/qcom/camera" />
     <remove-project name="platform/hardware/qcom/data/ipacfg-mgr" />
     <remove-project name="platform/hardware/qcom/display" />
     <remove-project name="platform/hardware/qcom/gps" />
     <remove-project name="platform/hardware/qcom/media" />
-    <remove-project name="platform/hardware/qcom/msm8x09" />
     <remove-project name="platform/hardware/qcom/msm8960" />
     <remove-project name="platform/hardware/qcom/msm8994" />
     <remove-project name="platform/hardware/qcom/msm8996" />
+    <remove-project name="platform/hardware/qcom/msm8x09" />
     <remove-project name="platform/hardware/qcom/msm8x26" />
     <remove-project name="platform/hardware/qcom/msm8x27" />
     <remove-project name="platform/hardware/qcom/msm8x84" />

--- a/untracked_kernel.xml
+++ b/untracked_kernel.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remove-project name="kernel/prebuilts/4.19/arm64" />
+    <!-- Keep for virtualization tests -->
+    <!-- <remove-project name="kernel/prebuilts/5.10/arm64" /> -->
+    <remove-project name="kernel/prebuilts/5.10/x86-64" />
+    <remove-project name="kernel/prebuilts/5.4/arm64" />
+    <remove-project name="kernel/prebuilts/5.4/x86-64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/4.19/arm64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/4.19/x86-64" />
+    <!-- Keep for microdroid and all the dependent virtualization packages -->
+    <!-- <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.10/arm64" /> -->
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.10/x86-64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.4/arm64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/5.4/x86-64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/mainline/arm64" />
+    <remove-project name="kernel/prebuilts/common-modules/virtual-device/mainline/x86-64" />
+    <remove-project name="kernel/prebuilts/mainline/arm64" />
+    <remove-project name="kernel/tests" />
 </manifest>

--- a/untracked_packages.xml
+++ b/untracked_packages.xml
@@ -3,24 +3,25 @@
     <!-- Not building for cars... -->
     <remove-project name="platform/packages/apps/Car/Calendar" />
     <remove-project name="platform/packages/apps/Car/Cluster" />
+    <remove-project name="platform/packages/apps/Car/DebuggingRestrictionController" />
     <remove-project name="platform/packages/apps/Car/Dialer" />
     <remove-project name="platform/packages/apps/Car/Hvac" />
     <remove-project name="platform/packages/apps/Car/LatinIME" />
     <remove-project name="platform/packages/apps/Car/Launcher" />
     <remove-project name="platform/packages/apps/Car/LinkViewer" />
-    <!-- PackageInstaller depends on car-list, which is in the libs: -->
-    <!--<remove-project name="platform/packages/apps/Car/libs" />-->
     <remove-project name="platform/packages/apps/Car/LocalMediaPlayer" />
     <remove-project name="platform/packages/apps/Car/Media" />
     <remove-project name="platform/packages/apps/Car/Messenger" />
-    <!--
-    frameworks/base/packages/CarSystemUI (which cannot be untracked)
-    depends on the Notification package.
-    -->
-    <!-- <remove-project name="platform/packages/apps/Car/Notification" /> -->
+    <remove-project name="platform/packages/apps/Car/Notification" />
+    <remove-project name="platform/packages/apps/Car/Provision" />
     <remove-project name="platform/packages/apps/Car/Radio" />
-    <remove-project name="platform/packages/apps/Car/RotaryController" />
+    <!-- Used by cts tests -->
+    <!-- <remove-project name="platform/packages/apps/Car/RotaryController" /> -->
     <remove-project name="platform/packages/apps/Car/Settings" />
+    <remove-project name="platform/packages/apps/Car/SettingsIntelligence" />
+    <remove-project name="platform/packages/apps/Car/SystemUI" />
     <remove-project name="platform/packages/apps/Car/SystemUpdater" />
+    <!-- Various packages depend on carg-ui-lib: -->
+    <!-- <remove-project name="platform/packages/apps/Car/libs" /> -->
     <remove-project name="platform/packages/apps/Car/tests" />
 </manifest>


### PR DESCRIPTION
See https://github.com/sonyxperiadev/device-sony-common/pull/880 for a detailed explanation of why we're switching to CAF's bootctrl instead of being stuck on AOSP's older bootctrl libhardware library that isn't loaded by AOSPs 1.1 default implementation.

Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>

@jerpelea This should be picked to R to fix https://github.com/sonyxperiadev/bug_tracker/issues/740, successfully tested: https://github.com/sonyxperiadev/device-sony-common/pull/880#issuecomment-1018476886

But that results on some merge-conflicts that have to be resolved during your rebase...

**Warning: this is a draft until _all_ platforms have been tested. While unlikely, perhaps some (supported on R!!) do not function with this HAL (even though all should, it's the same underlying implementation :crossed_fingers:).**