### PR TITLE
qcom-sm8450.xml: Add Display and media HALs for 5.10

### DIFF
--- a/qcom-sm8450.xml
+++ b/qcom-sm8450.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+
+<project path="vendor/qcom/opensource/display/sm8450" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/DISPLAY.LA.2.0.r1" />
+<project path="vendor/qcom/opensource/display-commonsys-intf/sm8450" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.QSSI.12.0.r1" />
+<project path="vendor/qcom/opensource/media/sm8450" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
+</manifest>


### PR DESCRIPTION
These HALs are utilized by Nagara platform running 5.10 kernel

Depends on https://github.com/sonyxperiadev/vendor-qcom-opensource-display/pull/5 to build

Signed-off-by: Martin Botka <martin.botka@somainline.org>