### PR TITLE
[13] Cleanup

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -2,9 +2,15 @@
 <manifest>
     <remove-project name="device/amlogic/yukawa" />
     <remove-project name="device/amlogic/yukawa-kernel" />
+    <remove-project name="device/common" />
     <remove-project name="device/generic/arm64" />
     <remove-project name="device/generic/armv7-a-neon" />
+    <remove-project name="device/generic/art" />
     <remove-project name="device/generic/car" />
+    <remove-project name="device/generic/common" />
+    <!-- Needed for cuttlefish com.google.aosp_cf_slim.rros apex module -->
+    <!-- <remove-project name="device/generic/goldfish" /> -->
+    <!-- <remove-project name="device/generic/goldfish-opengl" /> -->
     <remove-project name="device/generic/mini-emulator-arm64" />
     <remove-project name="device/generic/mini-emulator-armv7-a-neon" />
     <remove-project name="device/generic/mini-emulator-x86" />

--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -35,6 +35,11 @@
     <!-- Device repo provides core libraries for ie. microdroid -->
     <!-- <remove-project name="device/google/cuttlefish" /> -->
     <!-- <remove-project name="device/google/cuttlefish_prebuilts" /> -->
+    <remove-project name="device/google/gs201" />
+    <remove-project name="device/google/gs201-sepolicy" />
+    <remove-project name="device/google/pantah" />
+    <remove-project name="device/google/pantah-kernel" />
+    <remove-project name="device/google/pantah-sepolicy" />
     <remove-project name="device/google/redbull" />
     <remove-project name="device/google/redbull-kernel" />
     <remove-project name="device/google/redbull-sepolicy" />

--- a/untracked_packages.xml
+++ b/untracked_packages.xml
@@ -4,11 +4,14 @@
     <remove-project name="platform/packages/apps/Car/Calendar" />
     <remove-project name="platform/packages/apps/Car/Cluster" />
     <remove-project name="platform/packages/apps/Car/DebuggingRestrictionController" />
+    <!-- <remove-project name="platform/packages/apps/Car/Dialer" /> -->
     <remove-project name="platform/packages/apps/Car/Hvac" />
     <remove-project name="platform/packages/apps/Car/LatinIME" />
     <remove-project name="platform/packages/apps/Car/Launcher" />
     <remove-project name="platform/packages/apps/Car/LinkViewer" />
     <remove-project name="platform/packages/apps/Car/LocalMediaPlayer" />
+    <!-- <remove-project name="platform/packages/apps/Car/Media" /> -->
+    <!-- <remove-project name="platform/packages/apps/Car/Messenger" /> -->
     <!-- <remove-project name="platform/packages/apps/Car/Notification" /> -->
     <remove-project name="platform/packages/apps/Car/Provision" />
     <remove-project name="platform/packages/apps/Car/Radio" />
@@ -17,7 +20,9 @@
     <!-- <remove-project name="platform/packages/apps/Car/Settings" /> -->
     <remove-project name="platform/packages/apps/Car/SettingsIntelligence" />
     <!-- <remove-project name="platform/packages/apps/Car/SystemUI" /> -->
+    <!-- Various packages depend on car-assist-client-lib -->
+    <!-- <remove-project name="platform/packages/apps/Car/systemlibs" /> -->
     <remove-project name="platform/packages/apps/Car/SystemUpdater" />
-    <!-- Various packages depend on carg-ui-lib: -->
-    <!-- <remove-project name="platform/packages/apps/Car/libs" /> -->
+    <!-- tools/security depends on carwatchdogd_defaults etc -->
+    <!-- <remove-project name="platform/packages/services/Car" /> -->
 </manifest>


### PR DESCRIPTION
@ShujathMoh we typically comment out repos that _still exist_ but break the build, and document (contrary to what @Haxk20 suggested in [1]) what depends on them.

Also, what broke for you when missing `device/common` and `device/generic/art`? I just performed a successful build without these.

[1]: https://github.com/sonyxperiadev/local_manifests/pull/138#pullrequestreview-1075478010
