### PR TITLE
[13] Untrack google devices

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -54,6 +54,9 @@
     <remove-project name="device/google/sunfish" />
     <remove-project name="device/google/sunfish-kernel" />
     <remove-project name="device/google/sunfish-sepolicy" />
+    <remove-project name="device/google/tangorpro" />
+    <remove-project name="device/google/tangorpro-kernel" />
+    <remove-project name="device/google/tangorpro-sepolicy" />
     <remove-project name="device/google/trout" />
     <remove-project name="device/google/vrservices" />
     <remove-project name="device/google_car" />

--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -35,6 +35,9 @@
     <!-- Device repo provides core libraries for ie. microdroid -->
     <!-- <remove-project name="device/google/cuttlefish" /> -->
     <!-- <remove-project name="device/google/cuttlefish_prebuilts" /> -->
+    <remove-project name="device/google/felix" />
+    <remove-project name="device/google/felix-kernel" />
+    <remove-project name="device/google/felix-sepolicy" />
     <remove-project name="device/google/gs201" />
     <remove-project name="device/google/gs201-sepolicy" />
     <remove-project name="device/google/lynx" />

--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -41,6 +41,8 @@
     <remove-project name="device/google/gs201" />
     <remove-project name="device/google/gs201-sepolicy" />
     <remove-project name="device/google/lynx" />
+    <remove-project name="device/google/lynx-kernel" />
+    <remove-project name="device/google/lynx-sepolicy" />
     <remove-project name="device/google/pantah" />
     <remove-project name="device/google/pantah-kernel" />
     <remove-project name="device/google/pantah-sepolicy" />


### PR DESCRIPTION
Untrack the google devices felix, lynx and tangorpro.
They break the building of aosp.

Fixes https://github.com/sonyxperiadev/bug_tracker/issues/801