### PR TITLE
Re-track some necessary repos for AOSP 14

### DIFF
--- a/untracked_frameworks.xml
+++ b/untracked_frameworks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remove-project name="platform/frameworks/opt/car/setupwizard" />
-    <remove-project name="platform/frameworks/opt/car/services" />
+    <!-- <remove-project name="platform/frameworks/opt/car/setupwizard" /> -->
+    <!-- <remove-project name="platform/frameworks/opt/car/services" /> -->
 </manifest>

--- a/untracked_hardware.xml
+++ b/untracked_hardware.xml
@@ -22,5 +22,4 @@
     <remove-project name="platform/hardware/qcom/sm8150/thermal" />
     <remove-project name="platform/hardware/qcom/sm8150/vr" />
     <remove-project name="platform/hardware/qcom/sm8150p/gps" />
-    <remove-project name="platform/hardware/qcom/wlan" />"
 </manifest>

--- a/untracked_kernel.xml
+++ b/untracked_kernel.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remove-project name="kernel/configs" />
     <remove-project name="kernel/prebuilts/4.19/arm64" />
     <remove-project name="kernel/prebuilts/5.4/arm64" />
     <remove-project name="kernel/prebuilts/5.4/x86-64" />

--- a/untracked_packages.xml
+++ b/untracked_packages.xml
@@ -6,12 +6,12 @@
     <remove-project name="platform/packages/apps/Car/DebuggingRestrictionController" />
     <remove-project name="platform/packages/apps/Car/DialerPrebuilt" />
     <remove-project name="platform/packages/apps/Car/LatinIME" />
-    <remove-project name="platform/packages/apps/Car/Launcher" />
+    <!-- <remove-project name="platform/packages/apps/Car/Launcher" /> -->
     <remove-project name="platform/packages/apps/Car/LinkViewer" />
     <remove-project name="platform/packages/apps/Car/LocalMediaPlayer" />
     <remove-project name="platform/packages/apps/Car/MediaPrebuilt" />
     <remove-project name="platform/packages/apps/Car/MessengerPrebuilt" />
-    <remove-project name="platform/packages/apps/Car/Notification" />
+    <!-- <remove-project name="platform/packages/apps/Car/Notification" /> -->
     <remove-project name="platform/packages/apps/Car/Provision" />
     <remove-project name="platform/packages/apps/Car/Radio" />
     <!-- Used by cts tests -->
@@ -23,5 +23,5 @@
     <!-- <remove-project name="platform/packages/apps/Car/systemlibs" /> -->
     <remove-project name="platform/packages/apps/Car/SystemUpdater" />
     <!-- tools/security depends on carwatchdogd_defaults etc -->
-    <remove-project name="platform/packages/services/Car" />
+    <!-- <remove-project name="platform/packages/services/Car" /> -->
 </manifest>


### PR DESCRIPTION
In #148 - a WIP PR - a bunch of annoying repos were untracked to see if they could finally be skipped.  Unfortunately it turns out most of these have to be restored to make the build succeed.

In addition `bash` history suggests that I went through the same hopes and process last year.
