### PR TITLE
Update oss.xml

### DIFF
--- a/oss.xml
+++ b/oss.xml
@@ -2,7 +2,7 @@
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 <project path="vendor/oss/cash"  name="vendor-sony-oss-cash" groups="device" remote="sony" revision="master" />
-<project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="master" />
+<project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="r-mr1" />
 <project path="vendor/oss/json-c"  name="json-c" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/opentelephony" name="SonyOpenTelephony" groups="device" remote="sony" revision="r-mr1" />


### PR DESCRIPTION
Using "master" for fingerprint does not allow building. "r-mr1" fixes the build error for fingerprint. Building for G8141.