### PR TITLE
[Android 11] oss: Point `fingerprint` repository to `r-mr1` branch

### DIFF
--- a/oss.xml
+++ b/oss.xml
@@ -2,7 +2,7 @@
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 <project path="vendor/oss/cash"  name="vendor-sony-oss-cash" groups="device" remote="sony" revision="master" />
-<project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="master" />
+<project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="r-mr1" />
 <project path="vendor/oss/json-c"  name="json-c" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
 <project path="vendor/oss/opentelephony" name="SonyOpenTelephony" groups="device" remote="sony" revision="r-mr1" />


### PR DESCRIPTION
Starting with Android 11 (and up) we always target the `master` branch for our `fingerprint` repo, making it impossible to merge features and fixes for future Android versions without breaking older Android versions (in this case mandatory to support newer kernels), as is the case with: https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/76

In order to prevent Android 11 from using code a new `r-mr1` branch was created, pointing to the commit _before_ that PR was merged.  This means Android 11 will now miss out on any future improvements we might push to the `master` branch though.
