### PR TITLE
[Android 13] qcom-sm8550: Provide HALs for kernel 5.15

### DIFF
--- a/qcom-sm8550.xml
+++ b/qcom-sm8550.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="sony" fetch="https://github.com/sonyxperiadev/" />
+
+<project path="vendor/qcom/opensource/display/sm8550" name="vendor-qcom-opensource-display" groups="device" remote="sony" revision="aosp/DISPLAY.LA.3.0.r1" />
+<project path="vendor/qcom/opensource/display-commonsys-intf/sm8550" name="vendor-qcom-opensource-commonsys-intf-display" groups="device" remote="sony" revision="aosp/LA.QSSI.13.0.r1" />
+<project path="vendor/qcom/opensource/media/sm8550" name="vendor-qcom-opensource-media" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
+</manifest>

--- a/qcom.xml
+++ b/qcom.xml
@@ -16,7 +16,7 @@
 <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
 <project path="vendor/qcom/opensource/telephony" name="vendor-qcom-opensource-telephony" groups="device" remote="sony" revision="aosp/LA.QSSI.12.0.r1" />
 
-<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.QSSI.12.0.r1" />
+<project path="vendor/qcom/opensource/interfaces" name="vendor-qcom-opensource-interfaces" groups="device" remote="sony" revision="aosp/LA.QSSI.13.0.r1" />
 
 <project path="vendor/qcom/opensource/usb" name="vendor-qcom-opensource-usb" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
 


### PR DESCRIPTION
1. Provide HALs which will be used for devices running on kernel 5.15.
2. Bump interfaces repo to LA.QSSI.13.0.r1. Required for the latest HALs. Backwards compatible with all previous versions. I hope one day we will align all the other repositories.