### PR TITLE
Android 14.0.0 r30

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -16,7 +16,6 @@
     <remove-project name="device/generic/mini-emulator-x86" />
     <remove-project name="device/generic/mini-emulator-x86_64" />
     <remove-project name="device/generic/opengl-transport" />
-    <remove-project name="device/generic/qemu" />
     <remove-project name="device/generic/trusty" />
     <remove-project name="device/generic/uml" />
     <!-- Graphics Streaming Kit: Used in ie rutabaga_gfx -->
@@ -68,6 +67,4 @@
     <remove-project name="device/linaro/poplar-kernel" />
     <!-- Necessary for apns -->
     <!--<remove-project name="device/sample" />-->
-    <remove-project name="device/ti/beagle-x15" />
-    <remove-project name="device/ti/beagle-x15-kernel" />
 </manifest>

--- a/untracked_kernel.xml
+++ b/untracked_kernel.xml
@@ -7,8 +7,9 @@
     <remove-project name="kernel/prebuilts/5.10/x86-64" />
     <remove-project name="kernel/prebuilts/5.15/arm64" />
     <remove-project name="kernel/prebuilts/5.15/x86-64" />
-    <remove-project name="kernel/prebuilts/6.1/arm64" />
-    <remove-project name="kernel/prebuilts/6.1/x86-64" />
+    <!-- Needed for microdroid_gki_modules -->
+    <!--remove-project name="kernel/prebuilts/6.1/arm64" />
+    <remove-project name="kernel/prebuilts/6.1/x86-64" /-->
     <remove-project name="kernel/prebuilts/mainline/arm64" />
     <remove-project name="kernel/prebuilts/mainline/x86-64" />
     <remove-project name="kernel/prebuilts/common-modules/virtual-device/4.19/arm64" />


### PR DESCRIPTION
This PR contains two commits.

1, Removing non existent devices from untracked_devices.xml which prevents users from syncing due to non existent  error.
2. Tracking back kernel/prebuilts/6.1/arm64 and kernel/prebuilts/6.1/x86-64 as packages/modules/Virtualization/microdroid depends on it. This prevents users from building with the below error : 
error: packages/modules/Virtualization/microdroid/initrd/Android.bp:43:1: "microdroid_gki-android14-6.1_initrd_gen_arm64" depends on undefined module "microdroid_gki_modules-6.1-arm64".
Or did you mean ["libmicrodroid_metadata_proto_rust"]?
error: packages/modules/Virtualization/microdroid/initrd/Android.bp:54:1: "microdroid_gki-android14-6.1_initrd_gen_x86_64" depends on undefined module "microdroid_gki_modules-6.1-x86_64".
Or did you mean ["libmicrodroid_metadata_proto_rust"]?
fatal errors encountered