### PR TITLE
[Android 14 r1] qcom: Do not track WLAN repo

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -32,7 +32,6 @@
 
 <project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
-<project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
 
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />


### PR DESCRIPTION
It contains only the wcnss-service which has not been
used by any device for a very long time, and moreover,
we use AOSP HAL.