### PR TITLE
[Android 14 r1] Switch BootControl to LA.VENDOR.13.2.0.r1 branch

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -34,7 +34,7 @@
 <project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
 
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
-<project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
+<project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
 
 <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
 </manifest>

--- a/qcom.xml
+++ b/qcom.xml
@@ -35,6 +35,7 @@
 
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
+<project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-recovery-ext" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
 
 <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
 </manifest>


### PR DESCRIPTION
- Switch BootControl to LA.VENDOR.13.2.0.r1 branch.
This branch contains AIDL implementation.
- Track recovery-ext repo
Contains dependencies required for the latest BootControl.