### PR TITLE
qcom: Fix path of recovery-ext repo

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -35,7 +35,7 @@
 
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
-<project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-recovery-ext" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
+<project path="vendor/qcom/opensource/recovery-ext" name="vendor-qcom-opensource-recovery-ext" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
 
 <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
 </manifest>


### PR DESCRIPTION
Fixes repo sync after changes in https://github.com/sonyxperiadev/local_manifests/pull/159 caused a duplicate path in manifest.