### PR TITLE
[Android 14r1] qcom: Switch dataipa to LA.VENDOR.13.2.0.r1 branch

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -2,7 +2,8 @@
 <manifest>
 <remote name="sony" fetch="https://github.com/sonyxperiadev/" />
 
-<project path="vendor/qcom/opensource/data-ipacfg-mgr" name="vendor-qcom-opensource-data-ipa-cfg-mgr" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
+<project path="vendor/qcom/opensource/data-ipacfg-mgr" name="vendor-qcom-opensource-data-ipa-cfg-mgr" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
+<project path="vendor/qcom/opensource/data-ipacfg-mgr-legacy" name="vendor-qcom-opensource-data-ipa-cfg-mgr" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
 
 <project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
 <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />


### PR DESCRIPTION
Switch to upstream dataipa and keep LA.UM.9.16.r1 as a legacy variant for kernel 4.19 targets.