### PR TITLE
[Android 14r1] qcom: Switch gps/location to LA.VENDOR.13.2.0.r1 branch

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -5,8 +5,8 @@
 <project path="vendor/qcom/opensource/data-ipacfg-mgr" name="vendor-qcom-opensource-data-ipa-cfg-mgr" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
 <project path="vendor/qcom/opensource/data-ipacfg-mgr-legacy" name="vendor-qcom-opensource-data-ipa-cfg-mgr" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
 
-<project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
-<project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
+<project path="vendor/qcom/opensource/gps" name="hardware-qcom-gps" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
+<project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
 
 <project path="vendor/qcom/opensource/audio-hal/primary-hal" name="vendor-qcom-opensource-audio-hal-primary-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />
 <project path="vendor/qcom/opensource/audio-hal/st-hal" name="vendor-qcom-opensource-audio-hal-st-hal" groups="device" remote="sony" revision="aosp/LA.UM.9.16.r1" />


### PR DESCRIPTION
Switch to upstream gps/location. This branch contains AIDL implementation.