### PR TITLE
qcom: switch Vibrator to LA.VENDOR.13.2.0.r1 branch

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -32,7 +32,7 @@
 <project path="vendor/qcom/opensource/core-utils-vendor" name="vendor-qcom-opensource-core-utils-vendor" groups="device" remote="sony" revision="aosp/LA.VENDOR.1.0.r1" />
 
 <project path="vendor/qcom/opensource/bluetooth" name="vendor-qcom-opensource-bluetooth" groups="device" remote="sony" revision="master" />
-<project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.UM.7.1.r1" />
+<project path="vendor/qcom/opensource/vibrator" name="vendor-qcom-opensource-vibrator" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />
 
 <project path="vendor/qcom/opensource/gpt-utils" name="vendor-qcom-opensource-gpt-utils" groups="device" remote="sony" revision="master" />
 <project path="vendor/qcom/opensource/bootctrl" name="vendor-qcom-opensource-bootctrl" groups="device" remote="sony" revision="aosp/LA.VENDOR.13.2.0.r1" />


### PR DESCRIPTION
Contains aidl implementation

vibrator service doesnt get built since this commit https://github.com/sonyxperiadev/device-sony-common/commit/7458e7349af5b472634d8914fc095f35cb52ef90 which is aidl 

track the right repo 